### PR TITLE
코드래빗 추가

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "ko-KR"
+early_access: false
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: true
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+chat:
+  auto_reply: true


### PR DESCRIPTION
현재 리포지토리와 코드래빗을 연동하고,
코드래빗 코드 리뷰와 관련된 설정을 진행한다.

- 한국어 
- 베타 기능은 사용 안함
- `chill` 한 코드 리뷰: 기본적인 리뷰
- 모든 브랜치 코드 리뷰 허용
- 요약 기능 허용