### PR TITLE
[User]회원 핵심 로직 테스트 구현

### DIFF
--- a/src/test/java/com/book/laboratory/user/application/QuerydslSortUtilTest.java
+++ b/src/test/java/com/book/laboratory/user/application/QuerydslSortUtilTest.java
@@ -1,0 +1,76 @@
+package com.book.laboratory.user.application;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.book.laboratory.common.querydsl.QuerydslSortUtil;
+import com.book.laboratory.user.domain.User;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
+
+class QuerydslSortUtilTest {
+
+  @DisplayName("[toOrderSpecifiers]: 허용된 필드 정렬은 생성된다")
+  @Test
+  void shouldGenerateOrderSpecifiers_whenAllowedFieldsGiven() {
+    // Given
+    Sort sort = Sort.by(Sort.Order.asc("name"), Sort.Order.desc("createdAt"));
+    Set<String> allowedFields = Set.of("name", "createdAt");
+
+    // When
+    List<OrderSpecifier<?>> orderSpecifiers = QuerydslSortUtil.toOrderSpecifiers(
+        sort,
+        User.class,
+        "user",
+        allowedFields
+    );
+
+    // Then
+    assertThat(orderSpecifiers).hasSize(2);
+    assertThat(orderSpecifiers.get(0).getOrder()).isEqualTo(Order.ASC);
+    assertThat(orderSpecifiers.get(1).getOrder()).isEqualTo(Order.DESC);
+  }
+
+  @DisplayName("[toOrderSpecifiers]: 허용되지 않은 필드는 무시된다")
+  @Test
+  void shouldIgnoreFieldsNotInAllowedFields() {
+    // Given
+    Sort sort = Sort.by("name", "invalidField");
+    Set<String> allowedFields = Set.of("name");
+
+    // When
+    List<OrderSpecifier<?>> orderSpecifiers = QuerydslSortUtil.toOrderSpecifiers(
+        sort,
+        User.class,
+        "user",
+        allowedFields
+    );
+
+    // Then
+    assertThat(orderSpecifiers).hasSize(1); // invalidField 무시됨
+  }
+
+  @DisplayName("[toOrderSpecifiers]: 정렬 조건이 없으면 빈 리스트 반환")
+  @Test
+  void shouldReturnEmptyList_whenSortIsEmpty() {
+    // Given
+    Sort sort = Sort.unsorted();
+    Set<String> allowedFields = Set.of("id", "name");
+
+    // When
+    List<OrderSpecifier<?>> orderSpecifiers = QuerydslSortUtil.toOrderSpecifiers(
+        sort,
+        User.class,
+        "user",
+        allowedFields
+    );
+
+    // Then
+    assertThat(orderSpecifiers).isEmpty();
+  }
+}

--- a/src/test/java/com/book/laboratory/user/application/UserServiceGetMyInfoTest.java
+++ b/src/test/java/com/book/laboratory/user/application/UserServiceGetMyInfoTest.java
@@ -83,7 +83,7 @@ class UserServiceGetMyInfoTest {
   void ShouldThrowExceptionWhenRegularUserRequestsOtherUserInfo() {
     // given
     User otherUser = createUser(otherUserId, "other@example.com");
-    given(userRepository.findUserById(otherUserId)).willReturn(Optional.of(otherUser));
+//    given(userRepository.findUserById(otherUserId)).willReturn(Optional.of(otherUser));
 
     // when & then
     assertThatThrownBy(() -> userService.getMyInfo(regularUser, otherUserId))
@@ -95,7 +95,7 @@ class UserServiceGetMyInfoTest {
   @Test
   void ShouldThrowExceptionWhenUserNotFound() {
     // given
-    given(userRepository.findUserById(999L)).willReturn(Optional.empty());
+//    given(userRepository.findUserById(999L)).willReturn(Optional.empty());
 
     // when & then
     assertThatThrownBy(() -> userService.getMyInfo(regularUser, 999L))

--- a/src/test/java/com/book/laboratory/user/application/UserServiceGetMyInfoTest.java
+++ b/src/test/java/com/book/laboratory/user/application/UserServiceGetMyInfoTest.java
@@ -81,9 +81,6 @@ class UserServiceGetMyInfoTest {
   @DisplayName("[getMyInfo]: 일반 사용자가 다른 사용자 정보를 요청하면 예외 발생")
   @Test
   void ShouldThrowExceptionWhenRegularUserRequestsOtherUserInfo() {
-    // given
-    User otherUser = createUser(otherUserId, "other@example.com");
-//    given(userRepository.findUserById(otherUserId)).willReturn(Optional.of(otherUser));
 
     // when & then
     assertThatThrownBy(() -> userService.getMyInfo(regularUser, otherUserId))
@@ -94,8 +91,6 @@ class UserServiceGetMyInfoTest {
   @DisplayName("[getMyInfo]: 존재하지 않는 사용자 요청시 예외발생")
   @Test
   void ShouldThrowExceptionWhenUserNotFound() {
-    // given
-//    given(userRepository.findUserById(999L)).willReturn(Optional.empty());
 
     // when & then
     assertThatThrownBy(() -> userService.getMyInfo(regularUser, 999L))

--- a/src/test/java/com/book/laboratory/user/application/UserServiceGetUsersTest.java
+++ b/src/test/java/com/book/laboratory/user/application/UserServiceGetUsersTest.java
@@ -1,0 +1,126 @@
+package com.book.laboratory.user.application;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.book.laboratory.user.application.dto.condition.UserSearchCondition;
+import com.book.laboratory.user.application.dto.response.GetUsersResponseDto;
+import com.book.laboratory.user.domain.SocialType;
+import com.book.laboratory.user.domain.UserQueryRepository;
+import com.book.laboratory.user.domain.UserRole;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceGetUsersTest {
+
+  @InjectMocks
+  private UserServiceImpl userService;
+
+  @Mock
+  private UserQueryRepository userQueryRepository;
+
+
+  @DisplayName("[getUsers]: 조건 기반 회원 조회가 정상 수행된다")
+  @Test
+  void givenSearchCondition_whenGetUsers_thenReturnsPagedUserList() {
+    // Given
+    UserSearchCondition condition = new UserSearchCondition(
+        null, "홍길동", null,
+        UserRole.ROLE_USER, null, null,
+        null, null, null, null, null, null,
+        null, null, null
+    );
+
+    Pageable pageable = PageRequest.of(0, 10);
+    GetUsersResponseDto user1 = new GetUsersResponseDto(
+        1L, "홍길동", "hong@example.com", "img.jpg",
+        UserRole.ROLE_USER, SocialType.NONE, null,
+        LocalDateTime.now(), 1L,
+        null, null,
+        null, null
+    );
+
+    Page<GetUsersResponseDto> expectedPage = new PageImpl<>(List.of(user1), pageable, 1);
+
+    given(userQueryRepository.findUsersByCondition(condition, pageable)).willReturn(expectedPage);
+
+    // When
+    Page<GetUsersResponseDto> result = userService.getUsers(condition, pageable);
+
+    // Then
+    assertThat(result.getTotalElements()).isEqualTo(1);
+    assertThat(result.getContent().get(0).name()).isEqualTo("홍길동");
+    assertThat(result.getContent().get(0).email()).isEqualTo("hong@example.com");
+  }
+
+  @DisplayName("[getUsers]: 조건에 맞는 사용자가 없는 경우 빈 페이지 반환")
+  @Test
+  void shouldReturnEmptyResult_whenNoUserMatchesCondition() {
+    // Given
+    UserSearchCondition condition = new UserSearchCondition(
+        null, "없는이름", null,
+        null, null, null,
+        null, null, null, null, null, null,
+        null, null, null
+    );
+
+    Pageable pageable = PageRequest.of(0, 10);
+    Page<GetUsersResponseDto> emptyPage = Page.empty(pageable);
+
+    given(userQueryRepository.findUsersByCondition(condition, pageable)).willReturn(emptyPage);
+
+    // When
+    Page<GetUsersResponseDto> result = userService.getUsers(condition, pageable);
+
+    // Then
+    assertThat(result).isNotNull();
+    assertThat(result.isEmpty()).isTrue();
+    assertThat(result.getTotalElements()).isZero();
+  }
+
+  @DisplayName("[getUsers]: 생성일 범위 조건으로 사용자 조회")
+  @Test
+  void shouldReturnUsers_whenCreatedAtBetweenGiven() {
+    // Given
+    LocalDateTime from = LocalDateTime.now().minusDays(30);
+    LocalDateTime to = LocalDateTime.now();
+    UserSearchCondition condition = new UserSearchCondition(
+        null, null, null,
+        null, null, null,
+        from, to, null, null, null, null,
+        null, null, null
+    );
+
+    Pageable pageable = PageRequest.of(0, 10);
+    GetUsersResponseDto user1 = new GetUsersResponseDto(
+        1L, "user1", "user1@example.com", null,
+        UserRole.ROLE_USER, SocialType.NONE, null,
+        from.plusDays(1), 1L, null, null, null, null
+    );
+    Page<GetUsersResponseDto> page = new PageImpl<>(List.of(user1), pageable, 1);
+
+    given(userQueryRepository.findUsersByCondition(condition, pageable)).willReturn(page);
+
+    // When
+    Page<GetUsersResponseDto> result = userService.getUsers(condition, pageable);
+
+    // Then
+    assertThat(result.getTotalElements()).isEqualTo(1);
+    assertThat(result.getContent().get(0).createdAt()).isAfter(from);
+    assertThat(result.getContent().get(0).createdAt()).isBefore(to);
+  }
+
+
+
+}

--- a/src/test/java/com/book/laboratory/user/application/UserServiceSoftDeleteTest.java
+++ b/src/test/java/com/book/laboratory/user/application/UserServiceSoftDeleteTest.java
@@ -1,0 +1,109 @@
+package com.book.laboratory.user.application;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.book.laboratory.common.exception.CustomException;
+import com.book.laboratory.common.security.CustomUserDetails;
+import com.book.laboratory.user.application.dto.response.SoftDeleteResponseDto;
+import com.book.laboratory.user.domain.User;
+import com.book.laboratory.user.domain.UserErrorCode;
+import com.book.laboratory.user.domain.UserRepository;
+import com.book.laboratory.user.domain.UserRole;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceSoftDeleteTest {
+  @InjectMocks
+  private UserServiceImpl userService;
+
+  @Mock
+  private UserRepository userRepository;
+
+  private User user;
+  private User admin;
+
+  @BeforeEach
+  void setUp() {
+    user = User.builder()
+        .id(1L)
+        .name("홍길동")
+        .email("user@example.com")
+        .userRole(UserRole.ROLE_USER)
+        .build();
+
+    admin = User.builder()
+        .id(2L)
+        .name("관리자")
+        .email("admin@example.com")
+        .userRole(UserRole.ROLE_ADMIN)
+        .build();
+  }
+
+  @DisplayName("[softDeleteUser]: 일반 사용자가 자신의 계정을 삭제하면 삭제 처리됨")
+  @Test
+  void givenUserDeletingOwnAccount_whenSoftDelete_thenUserIsMarkedDeletedAndDtoReturned() {
+    // Given
+    CustomUserDetails userDetails = new CustomUserDetails(1L, "user@example.com", UserRole.ROLE_USER);
+    given(userRepository.findUserById(1L)).willReturn(Optional.of(user));
+
+    // When
+    SoftDeleteResponseDto result = userService.softDeleteUser(userDetails, 1L);
+
+    // Then
+    assertThat(result.id()).isEqualTo(1L);
+    assertThat(result.deletedBy()).isEqualTo(1L);
+    assertThat(user.getDeletedAt()).isNotNull();
+    assertThat(user.getDeletedBy()).isEqualTo(1L);
+  }
+
+  @DisplayName("[softDeleteUser]: 관리자가 다른 사용자를 삭제하면 삭제 처리됨")
+  @Test
+  void givenAdminDeletingAnotherUser_whenSoftDelete_thenTargetUserIsMarkedDeleted() {
+    // Given
+    CustomUserDetails adminDetails = new CustomUserDetails(2L, "admin@example.com", UserRole.ROLE_ADMIN);
+    given(userRepository.findUserById(1L)).willReturn(Optional.of(user));
+
+    // When
+    SoftDeleteResponseDto result = userService.softDeleteUser(adminDetails, 1L);
+
+    // Then
+    assertThat(result.id()).isEqualTo(1L);
+    assertThat(result.deletedBy()).isEqualTo(1L);
+    assertThat(user.getDeletedAt()).isNotNull();
+    assertThat(user.getDeletedBy()).isEqualTo(1L); // 삭제 대상 ID 기준
+  }
+
+  @DisplayName("[softDeleteUser]: 일반 사용자가 다른 사용자를 삭제하려 하면 예외 발생")
+  @Test
+  void givenUserDeletingOtherUser_whenSoftDelete_thenThrowsInvalidPatchUserException() {
+    // Given
+    CustomUserDetails userDetails = new CustomUserDetails(3L, "other@example.com", UserRole.ROLE_USER);
+
+    // When & Then
+    assertThatThrownBy(() -> userService.softDeleteUser(userDetails, 1L))
+        .isInstanceOf(CustomException.class)
+        .hasMessage(UserErrorCode.INVALID_PATCH_USER.getMessage());
+  }
+
+  @DisplayName("[softDeleteUser]: 존재하지 않는 사용자를 삭제 요청 시 예외 발생")
+  @Test
+  void givenUserNotFound_whenSoftDelete_thenThrowsUserNotFoundException() {
+    // Given
+    CustomUserDetails adminDetails = new CustomUserDetails(2L, "admin@example.com", UserRole.ROLE_ADMIN);
+    given(userRepository.findUserById(999L)).willReturn(Optional.empty());
+
+    // When & Then
+    assertThatThrownBy(() -> userService.softDeleteUser(adminDetails, 999L))
+        .isInstanceOf(CustomException.class)
+        .hasMessage(UserErrorCode.USER_NOT_FOUND_BY_ID.getMessage());
+  }
+}


### PR DESCRIPTION
Querydsl을 구현한 부분에 대한 테스트 코드를 작성했다.

1. 정렬 유틸 클래스 QuerydslSortIUtil 테스트 코드 작성
2. 권한에 따라 회원 정보 조회 분기 처리 구현
3. 권한에 따라 회원 삭제 분기 처리 구현
4. 회원 동적 조회 복잡한 조건 테스트 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **테스트**
    - 사용자 정렬 유틸리티의 동작을 검증하는 테스트가 추가되었습니다.
    - 사용자 목록 조회 서비스의 다양한 조건(검색, 날짜 범위 등)에 대한 테스트가 추가되었습니다.
    - 사용자 소프트 삭제(본인/관리자/예외 케이스 포함) 기능을 검증하는 테스트가 추가되었습니다.
    - 일부 사용자 정보 조회 테스트에서 목(Mock) 설정 코드가 주석 처리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->