### PR TITLE
[Swagger] 설정

### DIFF
--- a/src/main/java/com/book/laboratory/common/config/SecurityConfig.java
+++ b/src/main/java/com/book/laboratory/common/config/SecurityConfig.java
@@ -42,17 +42,15 @@ public class SecurityConfig {
     http
         .authorizeHttpRequests(auth -> auth
             .requestMatchers(
-                "/users/login", "/users/signup",
-                "/users/send/email-code", "/users/verify/email-code",
-                "/swagger-ui/**", "/v3/api-docs/**","/swagger-resources/**"
-                )
+                "/api/v1/users/login", "/api/v1/users/signup",
+                "/api/v1/users/send/email-code", "/api/v1/users/verify/email-code",
+                "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**"
+            )
             .permitAll()
             .anyRequest().authenticated());
 
     http
         .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class);
-
-
 
     return http.build();
   }

--- a/src/main/java/com/book/laboratory/common/config/SecurityConfig.java
+++ b/src/main/java/com/book/laboratory/common/config/SecurityConfig.java
@@ -41,7 +41,12 @@ public class SecurityConfig {
         .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
     http
         .authorizeHttpRequests(auth -> auth
-            .requestMatchers("/users/login", "/users/signup", "/users/send/email-code", "/users/verify/email-code").permitAll()
+            .requestMatchers(
+                "/users/login", "/users/signup",
+                "/users/send/email-code", "/users/verify/email-code",
+                "/swagger-ui/**", "/v3/api-docs/**","/swagger-resources/**"
+                )
+            .permitAll()
             .anyRequest().authenticated());
 
     http

--- a/src/main/java/com/book/laboratory/common/config/SwaggerConfig.java
+++ b/src/main/java/com/book/laboratory/common/config/SwaggerConfig.java
@@ -1,0 +1,29 @@
+package com.book.laboratory.common.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI getOpenAPI() {
+    return new OpenAPI()
+        .info(new Info()
+            .title("Laboratory API 문서")
+            .description("API 명세서입니다.")
+            .version("1.0.0"));
+  }
+
+  @Bean
+  public GroupedOpenApi publicApi() {
+    return GroupedOpenApi.builder()
+        .group("Laboratory API")
+        .pathsToMatch("/api/**")
+        .build();
+  }
+
+}

--- a/src/main/java/com/book/laboratory/user/application/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/book/laboratory/user/application/dto/request/SignupRequestDto.java
@@ -1,26 +1,36 @@
 package com.book.laboratory.user.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "회원가입 요청 DTO")
 public record SignupRequestDto(
 
+    @Schema(description = "이메일", example = "test@example.com")
     @NotBlank(message = "이메일: 이메일은 필수입니다.")
     @Email(message = "이메일: 유효하지 않은 이메일 형식입니다.")
     String email,
 
+    @Schema(description = "비밀번호", example = "P@ssw0rd!")
     @NotBlank(message = "비밀번호: 비밀번호는 필수입니다.")
     @Pattern(
         regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%?&]{8,}$",
         message = "비밀번호: 비밀번호는 최소 8자 이상이며, 영문자, 숫자, 특수문자(@, $, !, %, ?, &)를 포함해야 합니다.")
     String password,
 
+    @Schema(description = "이름", example = "외향적인새우초밥")
     @NotBlank(message = "이름: 이름은 필수입니다.")
-    @Size(max = 10, message = "이름: 이름은 10자 이하입니다.")
+    @Size(max = 10, message = "이름: 이름은 10자 이하입니다.") // 어느 조건이 틀렸는지 파악하기 용이!
+    @Pattern(
+        regexp = "^[가-힣a-zA-Z0-9]+$",
+        message = "이름: 한글, 영어 대소문자, 숫자만 입력 가능합니다."
+    )
     String name,
 
+    @Schema(description = "프로필사진", example = "https://aws.some_where/my_profile_image.png")
     String profileImageUrl
 ) {
 }

--- a/src/main/java/com/book/laboratory/user/application/dto/response/SignupResponseDto.java
+++ b/src/main/java/com/book/laboratory/user/application/dto/response/SignupResponseDto.java
@@ -1,12 +1,19 @@
 package com.book.laboratory.user.application.dto.response;
 
 import com.book.laboratory.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
+@Schema(description = "회원가입 응답 DTO")
 @Builder
 public record SignupResponseDto(
+    @Schema(description = "이메일", example = "test@example.com")
     String email,
+
+    @Schema(description = "이름", example = "외향적인새우초밥")
     String name,
+
+    @Schema(description = "프로필사진", example = "https://aws.some_where/my_profile_image.png")
     String profileImageUrl
 ) {
 

--- a/src/main/java/com/book/laboratory/user/presentation/UserApiSwagger.java
+++ b/src/main/java/com/book/laboratory/user/presentation/UserApiSwagger.java
@@ -112,7 +112,7 @@ public interface UserApiSwagger {
                           value = """
                               {
                                 "code": "400",
-                                "message": "비밀번호: 비밀번호는 최소 8자 이상이며, 영문자, 숫자, 특수문자를 포함해야 합니다.",
+                                "message": "비밀번호: 비밀번호는 최소 8자 이상이며, 영문자, 숫자, 특수문자(@, $, !, %, *, ?, &)를 포함해야 합니다.",
                                 "errors": [
                                   {
                                     "field": "password",

--- a/src/main/java/com/book/laboratory/user/presentation/UserApiSwagger.java
+++ b/src/main/java/com/book/laboratory/user/presentation/UserApiSwagger.java
@@ -1,0 +1,147 @@
+package com.book.laboratory.user.presentation;
+
+import com.book.laboratory.user.application.dto.request.SignupRequestDto;
+import com.book.laboratory.user.application.dto.response.SignupResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "V1 회원 서비스", description = "회원 관련 API (회원가입, 로그인 등)")
+public interface UserApiSwagger {
+
+  @Operation(
+      summary = "회원가입",
+      description = """
+          <b>email(이메일, 필수)</b>: 유효한 이메일 형식이여야만 합니다. \n
+          password(비밀번호, 필수): 최소 8자 이상이며, 영어 대소문자, 숫자, 특수문자(@, $, !, %, ?, &)를 포함해야 합니다. \n
+          name(이름, 필수): 최대 10자 이하이며, 한글, 영어 대소문자, 숫자만 입력 가능합니다. \n
+          profileImageUrl(프로필사진, 선택): 프로필 사진입니다. \n
+          """,
+      requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+          required = true,
+          content = @Content(
+              mediaType = "application/json",
+              examples = {
+                  @ExampleObject(
+                      name = "정상적인 회원가입 요청",
+                      summary = "정상적인 요청",
+                      value = """
+                          {
+                            "email": "test@example.com",
+                            "password": "P@ssw0rd123!",
+                            "name": "외향적인새우초밥",
+                            "profileImageUrl": "https://aws.some_where/my_profile_image.png"
+                          }
+                          """
+                  ),
+                  @ExampleObject(
+                      name = "이메일 누락 요청",
+                      summary = "email 누락된 요청",
+                      value = """
+                          {
+                            "email": "",
+                            "password": "P@ssw0rd123!",
+                            "name": "새우",
+                            "profileImageUrl": "https://aws.some_where/pic.png"
+                          }
+                          """
+                  ),
+                  @ExampleObject(
+                      name = "비밀번호 유효성 실패 요청",
+                      summary = "숫자/특수문자 없는 비밀번호",
+                      value = """
+                          {
+                            "email": "user@example.com",
+                            "password": "password",
+                            "name": "새우",
+                            "profileImageUrl": "https://aws.some_where/pic.png"
+                          }
+                          """
+                  )
+              }
+          )
+      ),
+      responses = {
+          @ApiResponse(
+              responseCode = "201",
+              description = "회원가입 성공",
+              content = @Content(
+                  mediaType = "application/json",
+                  examples = @ExampleObject(
+                      name = "회원가입 응답 예시",
+                      value = """
+                          {
+                            "email": "test@example.com",
+                            "name": "외향적인새우초밥",
+                            "profileImageUrl": "https://aws.some_where/my_profile_image.png"
+                          }
+                          """
+                  )
+              )
+          ),
+          @ApiResponse(
+              responseCode = "400",
+              description = "유효성 검증 실패",
+              content = @Content(
+                  mediaType = "application/json",
+                  examples = {
+                      @ExampleObject(
+                          name = "이메일 누락 오류",
+                          summary = "email 빈값 오류",
+                          value = """
+                              {
+                                "code": "400",
+                                "message": "이메일: 이메일은 필수입니다.",
+                                "errors": [
+                                  {
+                                    "field": "email",
+                                    "reason": "이메일은 빈값일 수 없습니다."
+                                  }
+                                ]
+                              }
+                              """
+                      ),
+                      @ExampleObject(
+                          name = "비밀번호 유효성 오류",
+                          summary = "비밀번호 형식 오류",
+                          value = """
+                              {
+                                "code": "400",
+                                "message": "비밀번호: 비밀번호는 최소 8자 이상이며, 영문자, 숫자, 특수문자를 포함해야 합니다.",
+                                "errors": [
+                                  {
+                                    "field": "password",
+                                    "reason": "형식이 올바르지 않습니다."
+                                  }
+                                ]
+                              }
+                              """
+                      )
+                  }
+              )
+          ),
+          @ApiResponse(
+              responseCode = "409",
+              description = "이미 가입된 이메일",
+              content = @Content(
+                  mediaType = "application/json",
+                  examples = @ExampleObject(
+                      name = "중복 이메일 응답 예시",
+                      value = """
+                          {
+                            "code": "409",
+                            "message": "이미 존재하는 이메일입니다."
+                          }
+                          """
+                  )
+              )
+          )
+      }
+  )
+  ResponseEntity<SignupResponseDto> signup(@RequestBody @Valid SignupRequestDto requestDto);
+}

--- a/src/main/java/com/book/laboratory/user/presentation/UserController.java
+++ b/src/main/java/com/book/laboratory/user/presentation/UserController.java
@@ -22,6 +22,7 @@ import com.book.laboratory.user.application.dto.response.SoftDeleteResponseDto;
 import com.book.laboratory.user.application.dto.response.UpdateUserEmailResponseDto;
 import com.book.laboratory.user.application.dto.response.UpdateUserInfoResponseDto;
 import com.book.laboratory.user.application.dto.response.UpdateUserRoleRequestDto;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -49,14 +50,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
-@RequestMapping("/users")
 @RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
 @RestController
-public class UserController {
+public class UserController implements UserApiSwagger {
 
   private final UserService userService;
 
   @PostMapping("/signup")
+  @Override
   public ResponseEntity<SignupResponseDto> signup(
       @RequestBody @Valid SignupRequestDto requestDto) {
     SignupResponseDto responseDto = userService.signup(requestDto);

--- a/src/main/java/com/book/laboratory/user/presentation/UserController.java
+++ b/src/main/java/com/book/laboratory/user/presentation/UserController.java
@@ -22,7 +22,6 @@ import com.book.laboratory.user.application.dto.response.SoftDeleteResponseDto;
 import com.book.laboratory.user.application.dto.response.UpdateUserEmailResponseDto;
 import com.book.laboratory.user.application.dto.response.UpdateUserInfoResponseDto;
 import com.book.laboratory.user.application.dto.response.UpdateUserRoleRequestDto;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
스웨거 설정 적용

- 회원가입 API만 요구사항에 따라 설정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Swagger UI 및 API 문서 엔드포인트에 인증 없이 접근할 수 있도록 공개 범위가 확장되었습니다.
  - Swagger/OpenAPI 기반의 자동 API 문서화 및 그룹화가 추가되었습니다.
  - 회원 가입 API에 대한 상세 예시와 응답, 오류 케이스 등 Swagger 문서가 대폭 보강되었습니다.

- **Documentation**
  - 회원 가입 요청/응답 DTO에 Swagger 문서용 설명과 예시가 추가되었습니다.
  - 회원 가입 API의 필드별 유효성 규칙 및 오류 예시가 문서화되었습니다.

- **Refactor**
  - 회원 관련 API의 기본 경로가 "/users"에서 "/api/v1/users"로 변경되었습니다.
  - UserController가 Swagger 문서 인터페이스를 구현하도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->